### PR TITLE
fix: EnvironmentName should be case-sensitive

### DIFF
--- a/sandbox/SingleContainedAppWithConfig/Program.cs
+++ b/sandbox/SingleContainedAppWithConfig/Program.cs
@@ -36,7 +36,7 @@ namespace SingleContainedAppWithConfig
                 .ConfigureAppConfiguration((hostContext, config) =>
                 {
                     // Set Environment variable "NETCORE_ENVIRONMENT" as Production | Staging | Development
-                    hostContext.HostingEnvironment.EnvironmentName = Environment.GetEnvironmentVariable("NETCORE_ENVIRONMENT") ?? "production";
+                    hostContext.HostingEnvironment.EnvironmentName = Environment.GetEnvironmentVariable("NETCORE_ENVIRONMENT") ?? "Production";
                     config.SetBasePath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location))
                         .AddJsonFile($"appsettings.json", optional: true, reloadOnChange: true)
                         .AddJsonFile($"appsettings.{hostContext.HostingEnvironment.EnvironmentName}.json", optional: true, reloadOnChange: true);


### PR DESCRIPTION
EnvironmentName should be case-sensitive. Some file systems are case-insensitive.
The batch app may fail to read a appsettings.Development.json.

## in Windows
```
C:\> dotnet run
info: MicroBatchFramework.BatchEngine[0]
      GlobalValue: GLOBAL VALUE!!!!, EnvValue: ENV VALUE!!!!
```

## in Linux
```
$ dotnet run
info: MicroBatchFramework.BatchEngine[0]
      GlobalValue: GLOBAL VALUE!!!!, EnvValue: ENV VALUE!!!!(PRODUCTION)

```