### PR TITLE
feat: Pass logger and ServiceProvider to BatchInterceptor

### DIFF
--- a/src/MicroBatchFramework/BatchEngineService.cs
+++ b/src/MicroBatchFramework/BatchEngineService.cs
@@ -38,7 +38,7 @@ namespace MicroBatchFramework
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            await interceptor.OnBatchEngineBeginAsync();
+            await interceptor.OnBatchEngineBeginAsync(provider, logger);
 
             // raise after all event registered
             appLifetime.ApplicationStarted.Register(async state =>

--- a/src/MicroBatchFramework/IBatchInterceptor.cs
+++ b/src/MicroBatchFramework/IBatchInterceptor.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Extensions.Logging;
+using System;
 using System.Threading.Tasks;
 
 namespace MicroBatchFramework
@@ -8,7 +9,7 @@ namespace MicroBatchFramework
         /// <summary>
         /// Called once when BatchEngineService is stareted.
         /// </summary>
-        ValueTask OnBatchEngineBeginAsync();
+        ValueTask OnBatchEngineBeginAsync(IServiceProvider serviceProvider, ILogger<BatchEngine> logger);
 
         /// <summary>
         /// Called once when BatchEngineService is finished.
@@ -31,7 +32,7 @@ namespace MicroBatchFramework
         public static readonly IBatchInterceptor Default = new NullBatchInerceptor();
         readonly ValueTask Empty = default(ValueTask);
 
-        public ValueTask OnBatchEngineBeginAsync()
+        public ValueTask OnBatchEngineBeginAsync(IServiceProvider serviceProvider, ILogger<BatchEngine> logger)
         {
             return Empty;
         }


### PR DESCRIPTION
In `OnBatchEngineBeginAsync` method, we want to use a logger and `IServiceProvider`.
For example, Initialize app or other dependent libraries, they need a logger or IServiceProvider. 