### PR TITLE
feat: Add MicroBatchHost as a Default Builder

### DIFF
--- a/sandbox/SingleContainedAppWithConfig/Program.cs
+++ b/sandbox/SingleContainedAppWithConfig/Program.cs
@@ -1,6 +1,6 @@
 ﻿using MicroBatchFramework;
+using MicroBatchFramework.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Threading.Tasks;
@@ -16,11 +16,12 @@ public class Baz : BatchBase
 
     public void Hello3()
     {
-        this.Context.Logger.LogTrace("Trace");
-        this.Context.Logger.LogDebug("Debug");
-        this.Context.Logger.LogInformation("Info");
-        this.Context.Logger.LogWarning("Warning");
-        this.Context.Logger.LogError("Error");
+        // https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.loglevel?view=aspnetcore-2.2
+        this.Context.Logger.LogTrace("Trace"); // 0
+        this.Context.Logger.LogDebug("Debug"); // 1
+        this.Context.Logger.LogInformation("Info"); // 2
+        this.Context.Logger.LogWarning("Warning"); // 3
+        this.Context.Logger.LogError("Error"); // 4
         this.Context.Logger.LogInformation($"GlobalValue: {config.Value.GlobalValue}, EnvValue: {config.Value.EnvValue}");
     }
 }
@@ -32,14 +33,14 @@ namespace SingleContainedAppWithConfig
     {
         static async Task Main(string[] args)
         {
-            await MicroBatchHost.CreateDefaultBuilder()
+            // using MicroBatchFramework.Configuration;
+            await MicroBatchHost.CreateDefaultBuilder(args, LogLevel.Debug)
                 .ConfigureServices((hostContext, services) =>
                 {
                     services.AddOptions();
                     // mapping json element to class
                     services.Configure<AppConfig>(hostContext.Configuration.GetSection("AppConfig"));
                 })
-                .ConfigureLogging(logging => logging.SetMinimumLevel(LogLevel.Debug)) // Default is Info. You can change Log Level at here
                 .RunBatchEngineAsync<Baz>(args);
         }
     }

--- a/sandbox/SingleContainedAppWithConfig/Program.cs
+++ b/sandbox/SingleContainedAppWithConfig/Program.cs
@@ -1,13 +1,7 @@
 ﻿using MicroBatchFramework;
-using MicroBatchFramework.Logging;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System;
-using System.IO;
-using System.Reflection;
 using System.Threading.Tasks;
 
 public class Baz : BatchBase
@@ -32,25 +26,12 @@ namespace SingleContainedAppWithConfig
     {
         static async Task Main(string[] args)
         {
-            await new HostBuilder()
-                .ConfigureAppConfiguration((hostContext, config) =>
-                {
-                    // Set Environment variable "NETCORE_ENVIRONMENT" as Production | Staging | Development
-                    hostContext.HostingEnvironment.EnvironmentName = Environment.GetEnvironmentVariable("NETCORE_ENVIRONMENT") ?? "Production";
-                    config.SetBasePath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location))
-                        .AddJsonFile($"appsettings.json", optional: true, reloadOnChange: true)
-                        .AddJsonFile($"appsettings.{hostContext.HostingEnvironment.EnvironmentName}.json", optional: true, reloadOnChange: true);
-                })
+            await MicroBatchHost.CreateDefaultBuilder()
                 .ConfigureServices((hostContext, services) =>
                 {
                     services.AddOptions();
                     // mapping json element to class
                     services.Configure<AppConfig>(hostContext.Configuration.GetSection("AppConfig"));
-                })
-                .ConfigureLogging(x =>
-                {
-                    // using MicroBatchFramework.Logging;
-                    x.AddSimpleConsole();
                 })
                 .RunBatchEngineAsync<Baz>(args);
         }

--- a/sandbox/SingleContainedAppWithConfig/Program.cs
+++ b/sandbox/SingleContainedAppWithConfig/Program.cs
@@ -1,5 +1,6 @@
 ﻿using MicroBatchFramework;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Threading.Tasks;
@@ -15,6 +16,11 @@ public class Baz : BatchBase
 
     public void Hello3()
     {
+        this.Context.Logger.LogTrace("Trace");
+        this.Context.Logger.LogDebug("Debug");
+        this.Context.Logger.LogInformation("Info");
+        this.Context.Logger.LogWarning("Warning");
+        this.Context.Logger.LogError("Error");
         this.Context.Logger.LogInformation($"GlobalValue: {config.Value.GlobalValue}, EnvValue: {config.Value.EnvValue}");
     }
 }
@@ -33,6 +39,7 @@ namespace SingleContainedAppWithConfig
                     // mapping json element to class
                     services.Configure<AppConfig>(hostContext.Configuration.GetSection("AppConfig"));
                 })
+                .ConfigureLogging(logging => logging.SetMinimumLevel(LogLevel.Debug)) // Default is Info. You can change Log Level at here
                 .RunBatchEngineAsync<Baz>(args);
         }
     }

--- a/src/MicroBatchFramework/Configuration/MicroBatchHost.cs
+++ b/src/MicroBatchFramework/Configuration/MicroBatchHost.cs
@@ -1,11 +1,12 @@
 ﻿using MicroBatchFramework.Logging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
 using System.Reflection;
 
-namespace MicroBatchFramework
+namespace MicroBatchFramework.Configuration
 {
     // ref: https://github.com/aspnet/AspNetCore/blob/4e44025a52e4b73aa17e09a8041b0e166e0c5ce0/src/DefaultBuilder/src/WebHost.cs
     /// <summary>
@@ -26,7 +27,7 @@ namespace MicroBatchFramework
         /// </remarks>
         /// <returns>The initialized <see cref="IHostBuilder"/>.</returns>
         public static IHostBuilder CreateDefaultBuilder() =>
-            CreateDefaultBuilder(args: null, hostEnvironmentVariable: "");
+            CreateDefaultBuilder(args: null);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HostBuilder"/> class with pre-configured defaults.
@@ -43,7 +44,25 @@ namespace MicroBatchFramework
         /// <param name="args"></param>
         /// <returns>The initialized <see cref="IHostBuilder"/>.</returns>
         public static IHostBuilder CreateDefaultBuilder(string[] args) =>
-            CreateDefaultBuilder(args, "");
+            CreateDefaultBuilder(args, new SimpleConsoleLoggerOption().MinLogLevel);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HostBuilder"/> class with pre-configured defaults.
+        /// </summary>
+        /// <remarks>
+        ///   The following defaults are applied to the returned <see cref="HostBuilder"/>:
+        ///     set the <see cref="IHostingEnvironment.EnvironmentName"/> to the NETCORE_ENVIRONMENT,
+        ///     load <see cref="IConfiguration"/> from 'appsettings.json' and 'appsettings.[<see cref="IHostingEnvironment.EnvironmentName"/>].json',
+        ///     load <see cref="IConfiguration"/> from User Secrets when <see cref="IHostingEnvironment.EnvironmentName"/> is 'Development' using the entry assembly,
+        ///     load <see cref="IConfiguration"/> from environment variables,
+        ///     load <see cref="IConfiguration"/> from supplied command line args,
+        ///     and configure the <see cref="SimpleConsoleLogger"/> to log to the console,
+        /// </remarks>
+        /// <param name="args"></param>
+        /// <param name="minLogLevel"></param>
+        /// <returns>The initialized <see cref="IHostBuilder"/>.</returns>
+        public static IHostBuilder CreateDefaultBuilder(string[] args, LogLevel minLogLevel) =>
+            CreateDefaultBuilder(args, minLogLevel, "");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HostBuilder"/> class with pre-configured defaults.
@@ -58,16 +77,22 @@ namespace MicroBatchFramework
         ///     and configure the <see cref="SimpleConsoleLogger"/> to log to the console,
         /// </remarks>
         /// <param name="args"></param>
+        /// <param name="minLogLevel"></param>
         /// <param name="hostEnvironmentVariable"></param>
         /// <returns>The initialized <see cref="IHostBuilder"/>.</returns>
-        public static IHostBuilder CreateDefaultBuilder(string[] args, string hostEnvironmentVariable)
+        public static IHostBuilder CreateDefaultBuilder(string[] args, LogLevel minLogLevel, string hostEnvironmentVariable)
         {
             var builder = new HostBuilder();
 
             builder.UseContentRoot(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
             ConfigureContextDefault(builder, hostEnvironmentVariable);
             ConfigureConfigDefault(builder, args);
-            return builder.ConfigureLogging(x => x.AddSimpleConsole());
+            return builder.ConfigureLogging(logging =>
+            {
+                logging.AddSimpleConsole();
+                // Set ILogger<MicroBatchFramework.BatchEngine> Minimum log level filter.
+                logging.AddFilter<SimpleConsoleLoggerProvider>($"MicroBatchFramework.{nameof(BatchEngine)}", minLogLevel);
+            });
         }
 
         internal static void ConfigureContextDefault(IHostBuilder builder, string contextEnvironmentVariable)

--- a/src/MicroBatchFramework/Configuration/MicroBatchHost.cs
+++ b/src/MicroBatchFramework/Configuration/MicroBatchHost.cs
@@ -87,12 +87,8 @@ namespace MicroBatchFramework.Configuration
             builder.UseContentRoot(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
             ConfigureContextDefault(builder, hostEnvironmentVariable);
             ConfigureConfigDefault(builder, args);
-            return builder.ConfigureLogging(logging =>
-            {
-                logging.AddSimpleConsole();
-                // Set ILogger<MicroBatchFramework.BatchEngine> Minimum log level filter.
-                logging.AddFilter<SimpleConsoleLoggerProvider>($"MicroBatchFramework.{nameof(BatchEngine)}", minLogLevel);
-            });
+            ConfigureLoggingDefault(builder, minLogLevel);
+            return builder;
         }
 
         internal static void ConfigureContextDefault(IHostBuilder builder, string contextEnvironmentVariable)
@@ -134,6 +130,16 @@ namespace MicroBatchFramework.Configuration
                 {
                     config.AddCommandLine(args);
                 }
+            });
+        }
+
+        internal static void ConfigureLoggingDefault(IHostBuilder builder, LogLevel minLogLevel)
+        {
+            builder.ConfigureLogging(logging =>
+            {
+                logging.AddSimpleConsole();
+                // Set ILogger<MicroBatchFramework.BatchEngine> Minimum log level filter.
+                logging.AddFilter<SimpleConsoleLoggerProvider>("MicroBatchFramework.BatchEngine", minLogLevel);
             });
         }
     }

--- a/src/MicroBatchFramework/MicroBatchFramework.csproj
+++ b/src/MicroBatchFramework/MicroBatchFramework.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -23,6 +23,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />

--- a/src/MicroBatchFramework/MicroBatchHost.cs
+++ b/src/MicroBatchFramework/MicroBatchHost.cs
@@ -1,0 +1,115 @@
+﻿using MicroBatchFramework.Logging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace MicroBatchFramework
+{
+    // ref: https://github.com/aspnet/AspNetCore/blob/4e44025a52e4b73aa17e09a8041b0e166e0c5ce0/src/DefaultBuilder/src/WebHost.cs
+    /// <summary>
+    /// Provides convenience methods for creating instances of <see cref="IHost"/> and <see cref="IHostBuilder"/> with pre-configured defaults.
+    /// </summary>
+    public static class MicroBatchHost
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HostBuilder"/> class with pre-configured defaults.
+        /// </summary>
+        /// <remarks>
+        ///   The following defaults are applied to the returned <see cref="HostBuilder"/>:
+        ///     set the <see cref="IHostingEnvironment.EnvironmentName"/> to the NETCORE_ENVIRONMENT,
+        ///     load <see cref="IConfiguration"/> from 'appsettings.json' and 'appsettings.[<see cref="IHostingEnvironment.EnvironmentName"/>].json',
+        ///     load <see cref="IConfiguration"/> from User Secrets when <see cref="IHostingEnvironment.EnvironmentName"/> is 'Development' using the entry assembly,
+        ///     load <see cref="IConfiguration"/> from environment variables,
+        ///     and configure the <see cref="SimpleConsoleLogger"/> to log to the console,
+        /// </remarks>
+        /// <returns>The initialized <see cref="IHostBuilder"/>.</returns>
+        public static IHostBuilder CreateDefaultBuilder() =>
+            CreateDefaultBuilder(args: null, hostEnvironmentVariable: "");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HostBuilder"/> class with pre-configured defaults.
+        /// </summary>
+        /// <remarks>
+        ///   The following defaults are applied to the returned <see cref="HostBuilder"/>:
+        ///     set the <see cref="IHostingEnvironment.EnvironmentName"/> to the NETCORE_ENVIRONMENT,
+        ///     load <see cref="IConfiguration"/> from 'appsettings.json' and 'appsettings.[<see cref="IHostingEnvironment.EnvironmentName"/>].json',
+        ///     load <see cref="IConfiguration"/> from User Secrets when <see cref="IHostingEnvironment.EnvironmentName"/> is 'Development' using the entry assembly,
+        ///     load <see cref="IConfiguration"/> from environment variables,
+        ///     load <see cref="IConfiguration"/> from supplied command line args,
+        ///     and configure the <see cref="SimpleConsoleLogger"/> to log to the console,
+        /// </remarks>
+        /// <param name="args"></param>
+        /// <returns>The initialized <see cref="IHostBuilder"/>.</returns>
+        public static IHostBuilder CreateDefaultBuilder(string[] args) =>
+            CreateDefaultBuilder(args, "");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HostBuilder"/> class with pre-configured defaults.
+        /// </summary>
+        /// <remarks>
+        ///   The following defaults are applied to the returned <see cref="HostBuilder"/>:
+        ///     set the <see cref="IHostingEnvironment.EnvironmentName"/> to the parameter of hostEnvironmentVariable,
+        ///     load <see cref="IConfiguration"/> from 'appsettings.json' and 'appsettings.[<see cref="IHostingEnvironment.EnvironmentName"/>].json',
+        ///     load <see cref="IConfiguration"/> from User Secrets when <see cref="IHostingEnvironment.EnvironmentName"/> is 'Development' using the entry assembly,
+        ///     load <see cref="IConfiguration"/> from environment variables,
+        ///     load <see cref="IConfiguration"/> from supplied command line args,
+        ///     and configure the <see cref="SimpleConsoleLogger"/> to log to the console,
+        /// </remarks>
+        /// <param name="args"></param>
+        /// <param name="hostEnvironmentVariable"></param>
+        /// <returns>The initialized <see cref="IHostBuilder"/>.</returns>
+        public static IHostBuilder CreateDefaultBuilder(string[] args, string hostEnvironmentVariable)
+        {
+            var builder = new HostBuilder();
+
+            builder.UseContentRoot(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+            ConfigureContextDefault(builder, hostEnvironmentVariable);
+            ConfigureConfigDefault(builder, args);
+            return builder.ConfigureLogging(x => x.AddSimpleConsole());
+        }
+
+        internal static void ConfigureContextDefault(IHostBuilder builder, string contextEnvironmentVariable)
+        {
+            builder.ConfigureAppConfiguration((hostingContext, config) =>
+            {
+                var env = hostingContext.HostingEnvironment;
+                env.ApplicationName = Assembly.GetExecutingAssembly().GetName().Name;
+                if (string.IsNullOrWhiteSpace(contextEnvironmentVariable))
+                {
+                    contextEnvironmentVariable = "NETCORE_ENVIRONMENT";
+                }
+                env.EnvironmentName = System.Environment.GetEnvironmentVariable(contextEnvironmentVariable) ?? "Production";
+            });
+        }
+
+        internal static void ConfigureConfigDefault(IHostBuilder builder, string[] args)
+        {
+            builder.ConfigureAppConfiguration((hostingContext, config) =>
+            {
+                var env = hostingContext.HostingEnvironment;
+
+                config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
+                config.AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true);
+
+                if (env.IsDevelopment())
+                {
+                    var appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
+                    if (appAssembly != null)
+                    {
+                        // use https://marketplace.visualstudio.com/items?itemName=guitarrapc.OpenUserSecrets to easily manage UserSecrets with GenericHost.
+                        config.AddUserSecrets(appAssembly, optional: true);
+                    }
+                }
+
+                config.AddEnvironmentVariables();
+
+                if (args != null)
+                {
+                    config.AddCommandLine(args);
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
## TL;DR;

Offer default builder as asp.net core webhost does.
This will make user don't need to think about configuration.

## Question 
Should Replace other samples to use MicroBatchHost?

## TODO

- [x] add default builder with SimpleLogger
- [x] refactor Configuration Sample
- [ ] add README section for MicroBatchHost
- [ ] fix README for Configuration Sample
