### PR TITLE
fix: Can't match implicit command argument.

### DIFF
--- a/src/MicroBatchFramework/BatchEngine.cs
+++ b/src/MicroBatchFramework/BatchEngine.cs
@@ -176,7 +176,7 @@ namespace MicroBatchFramework
                 var option = item.GetCustomAttribute<OptionAttribute>();
 
                 string value = null;
-                if (option.Index != -1)
+                if (option != null && option.Index != -1)
                 {
                     value = args[argsOffset + i];
                 }


### PR DESCRIPTION
If a batch method doesn't have any `Option` attribute, `BatchEngine` can't match any command argument.
It seems to works well when running MicroBatchFramework 0.3.1 or prior.

## Steps to reproduce
```
> cd sandbox\MultiContainedApp
> dotnet run Foo.Echo -msg hoge
Fail to match method parameter on Foo.Echo. args: Foo.Echo -msg hoge
System.NullReferenceException: Object reference not set to an instance of an object.
   at MicroBatchFramework.BatchEngine.TryGetInvokeArguments(ParameterInfo[] parameters, String[] args, Int32 argsOffset, Object[]& invokeArgs, String& errorMessage) in C:\Users\Tomoyo\Source\Repos\MicroBatchFramework\src\MicroBatchFramework\BatchEngine.cs:line 179
   at MicroBatchFramework.BatchEngine.RunCore(BatchContext ctx, Type type, MethodInfo methodInfo, String[] args, Int32 argsOffset) in C:\Users\Tomoyo\Source\Repos\MicroBatchFramework\src\MicroBatchFramework\BatchEngine.cs:line 100
```

## Expected result
```
> cd sandbox\MultiContainedApp
> dotnet run Foo.Echo -msg hoge
hoge
```