### PR TITLE
Remove SimpleConsoleLogger dependency from BatchEngine initialization.

### DIFF
--- a/sandbox/MultiContainedApp/Program.cs
+++ b/sandbox/MultiContainedApp/Program.cs
@@ -10,7 +10,7 @@ namespace MultiContainedApp
     {
         static async Task Main(string[] args)
         {
-            await BatchHost.CreateDefaultBuilder(useSimpleConosoleLogger:true)
+            await BatchHost.CreateDefaultBuilder()
                 .RunBatchEngineAsync(args);
         }
     }

--- a/sandbox/MultiContainedApp/Program.cs
+++ b/sandbox/MultiContainedApp/Program.cs
@@ -10,7 +10,8 @@ namespace MultiContainedApp
     {
         static async Task Main(string[] args)
         {
-            await BatchHost.CreateDefaultBuilder().RunBatchEngineAsync(args);
+            await BatchHost.CreateDefaultBuilder(useSimpleConosoleLogger:true)
+                .RunBatchEngineAsync(args);
         }
     }
 

--- a/src/MicroBatchFramework/BatchEngineHostBuilderExtensions.cs
+++ b/src/MicroBatchFramework/BatchEngineHostBuilderExtensions.cs
@@ -15,7 +15,7 @@ namespace MicroBatchFramework
         const string ListCommand = "list";
         const string HelpCommand = "help";
 
-        public static IHostBuilder UseBatchEngine(this IHostBuilder hostBuilder, string[] args, IBatchInterceptor interceptor = null, bool useSimpleConosoleLogger = true)
+        public static IHostBuilder UseBatchEngine(this IHostBuilder hostBuilder, string[] args, IBatchInterceptor interceptor = null)
         {
             if (args.Length == 0 || (args.Length == 1 && args[0].Equals(ListCommand, StringComparison.OrdinalIgnoreCase)))
             {
@@ -76,20 +76,15 @@ namespace MicroBatchFramework
                     }
                 });
 
-            if (useSimpleConosoleLogger)
-            {
-                hostBuilder = hostBuilder.ConfigureLogging(x => x.AddSimpleConsole());
-            }
-
             return hostBuilder.UseConsoleLifetime();
         }
 
-        public static Task RunBatchEngineAsync(this IHostBuilder hostBuilder, string[] args, IBatchInterceptor interceptor = null, bool useSimpleConosoleLogger = true)
+        public static Task RunBatchEngineAsync(this IHostBuilder hostBuilder, string[] args, IBatchInterceptor interceptor = null)
         {
-            return UseBatchEngine(hostBuilder, args, interceptor, useSimpleConosoleLogger).Build().RunAsync();
+            return UseBatchEngine(hostBuilder, args, interceptor).Build().RunAsync();
         }
 
-        public static IHostBuilder UseBatchEngine<T>(this IHostBuilder hostBuilder, string[] args, IBatchInterceptor interceptor = null, bool useSimpleConosoleLogger = true)
+        public static IHostBuilder UseBatchEngine<T>(this IHostBuilder hostBuilder, string[] args, IBatchInterceptor interceptor = null)
             where T : BatchBase
         {
             var method = typeof(T).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
@@ -151,18 +146,13 @@ namespace MicroBatchFramework
                 services.AddTransient<T>();
             });
 
-            if (useSimpleConosoleLogger)
-            {
-                hostBuilder = hostBuilder.ConfigureLogging(x => x.AddSimpleConsole());
-            }
-
             return hostBuilder.UseConsoleLifetime();
         }
 
-        public static Task RunBatchEngineAsync<T>(this IHostBuilder hostBuilder, string[] args, IBatchInterceptor interceptor = null, bool useSimpleConosoleLogger = true)
+        public static Task RunBatchEngineAsync<T>(this IHostBuilder hostBuilder, string[] args, IBatchInterceptor interceptor = null)
             where T : BatchBase
         {
-            return UseBatchEngine<T>(hostBuilder, args, interceptor, useSimpleConosoleLogger).Build().RunAsync();
+            return UseBatchEngine<T>(hostBuilder, args, interceptor).Build().RunAsync();
         }
 
         static void ShowMethodList()

--- a/src/MicroBatchFramework/BatchHost.cs
+++ b/src/MicroBatchFramework/BatchHost.cs
@@ -28,7 +28,7 @@ namespace MicroBatchFramework
         ///     and configure the <see cref="SimpleConsoleLogger"/> to log to the console,
         /// </remarks>
         /// <returns>The initialized <see cref="IHostBuilder"/>.</returns>
-        public static IHostBuilder CreateDefaultBuilder(bool useSimpleConosoleLogger = true) => CreateDefaultBuilder(useSimpleConosoleLogger, LogLevel.Debug);
+        public static IHostBuilder CreateDefaultBuilder(bool useSimpleConsoleLogger = true) => CreateDefaultBuilder(useSimpleConsoleLogger, LogLevel.Debug);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HostBuilder"/> class with pre-configured defaults.
@@ -41,10 +41,10 @@ namespace MicroBatchFramework
         ///     load <see cref="IConfiguration"/> from environment variables,
         ///     and configure the <see cref="SimpleConsoleLogger"/> to log to the console,
         /// </remarks>
-        /// <param name="useSimpleConosoleLogger"></param>
+        /// <param name="useSimpleConsoleLogger"></param>
         /// <param name="minSimpleConsoleLoggerLogLevel"></param>
         /// <returns>The initialized <see cref="IHostBuilder"/>.</returns>
-        public static IHostBuilder CreateDefaultBuilder(bool useSimpleConosoleLogger, LogLevel minSimpleConsoleLoggerLogLevel) => CreateDefaultBuilder(useSimpleConosoleLogger, minSimpleConsoleLoggerLogLevel, "");
+        public static IHostBuilder CreateDefaultBuilder(bool useSimpleConsoleLogger, LogLevel minSimpleConsoleLoggerLogLevel) => CreateDefaultBuilder(useSimpleConsoleLogger, minSimpleConsoleLoggerLogLevel, "");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HostBuilder"/> class with pre-configured defaults.
@@ -57,17 +57,17 @@ namespace MicroBatchFramework
         ///     load <see cref="IConfiguration"/> from environment variables,
         ///     and configure the <see cref="SimpleConsoleLogger"/> to log to the console,
         /// </remarks>
-        /// <param name="useSimpleConosoleLogger"></param>
+        /// <param name="useSimpleConsoleLogger"></param>
         /// <param name="minSimpleConsoleLoggerLogLevel"></param>
         /// <param name="hostEnvironmentVariable"></param>
         /// <returns>The initialized <see cref="IHostBuilder"/>.</returns>
-        public static IHostBuilder CreateDefaultBuilder(bool useSimpleConosoleLogger, LogLevel minSimpleConsoleLoggerLogLevel, string hostEnvironmentVariable)
+        public static IHostBuilder CreateDefaultBuilder(bool useSimpleConsoleLogger, LogLevel minSimpleConsoleLoggerLogLevel, string hostEnvironmentVariable)
         {
             var builder = new HostBuilder();
 
             ConfigureHostConfigurationDefault(builder, hostEnvironmentVariable);
             ConfigureAppConfigurationDefault(builder);
-            ConfigureLoggingDefault(builder, useSimpleConosoleLogger, minSimpleConsoleLoggerLogLevel);
+            ConfigureLoggingDefault(builder, useSimpleConsoleLogger, minSimpleConsoleLoggerLogLevel);
 
             return builder;
         }
@@ -111,9 +111,9 @@ namespace MicroBatchFramework
             });
         }
 
-        internal static void ConfigureLoggingDefault(IHostBuilder builder, bool useSimpleConosoleLogger, LogLevel minSimpleConsoleLoggerLogLevel)
+        internal static void ConfigureLoggingDefault(IHostBuilder builder, bool useSimpleConsoleLogger, LogLevel minSimpleConsoleLoggerLogLevel)
         {
-            if (useSimpleConosoleLogger)
+            if (useSimpleConsoleLogger)
             {
                 builder.ConfigureLogging(logging =>
                 {


### PR DESCRIPTION
`BatchHost.CreateDefaultBuilder` method has `useSimpleConsoleLogger` parameter, but `UseBatchEngine` and `RunBatchEngineAsync` methods also have `useSimpleConsoleLogger`.

If I want to disable SimpleConsoleLogger, I need to write `useSimpleConsoleLogger` in two places.

Considering consistency, I think that it is better not to add any logger in BatchEngine initialization process.