### PR TITLE
Upgrade Microsoft.Extensions.Hosting and .NET Core

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:2.2
+      - image: mcr.microsoft.com/dotnet/core/sdk:3.0
     environment:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
       NUGET_XMLDOC_MODE: skip

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -422,7 +422,7 @@ builder.UseContentRoot(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Loc
 // set the host configuration
 builder.ConfigureHostConfiguration(config =>
 {
-    config.AddEnvironmentVariables(prefix: "NETCORE_");
+    config.AddEnvironmentVariables(prefix: "DOTNET_");
     config.AddInMemoryCollection(new[] { new KeyValuePair<string, string>(HostDefaults.ApplicationKey, Assembly.GetExecutingAssembly().GetName().Name) });
 });
 

--- a/sandbox/MultiContainedApp/MultiContainedApp.csproj
+++ b/sandbox/MultiContainedApp/MultiContainedApp.csproj
@@ -7,12 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\MicroBatchFramework\MicroBatchFramework.csproj" />
   </ItemGroup>
 

--- a/sandbox/SingleContainedApp/SingleContainedApp.csproj
+++ b/sandbox/SingleContainedApp/SingleContainedApp.csproj
@@ -17,12 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\MicroBatchFramework\MicroBatchFramework.csproj" />
   </ItemGroup>
 

--- a/sandbox/SingleContainedAppWithConfig/SingleContainedAppWithConfig.csproj
+++ b/sandbox/SingleContainedAppWithConfig/SingleContainedAppWithConfig.csproj
@@ -29,13 +29,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\MicroBatchFramework\MicroBatchFramework.csproj" />
   </ItemGroup>
 

--- a/sandbox/WebHostingApp/WebHostingApp.csproj
+++ b/sandbox/WebHostingApp/WebHostingApp.csproj
@@ -2,16 +2,16 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\src\MicroBatchFramework.WebHosting\MicroBatchFramework.WebHosting.csproj" />
     <ProjectReference Include="..\..\src\MicroBatchFramework\MicroBatchFramework.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 </Project>

--- a/src/MicroBatchFramework.WebHosting/MicroBatchFramework.WebHosting.csproj
+++ b/src/MicroBatchFramework.WebHosting/MicroBatchFramework.WebHosting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,8 +9,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MicroBatchFramework/BatchHost.cs
+++ b/src/MicroBatchFramework/BatchHost.cs
@@ -22,7 +22,7 @@ namespace MicroBatchFramework
         /// </summary>
         /// <remarks>
         ///   The following defaults are applied to the returned <see cref="HostBuilder"/>:
-        ///     set the <see cref="IHostingEnvironment.EnvironmentName"/> to the NETCORE_ENVIRONMENT,
+        ///     set the <see cref="IHostingEnvironment.EnvironmentName"/> to the DOTNET_ENVIRONMENT,
         ///     load <see cref="IConfiguration"/> from 'appsettings.json' and 'appsettings.[<see cref="IHostingEnvironment.EnvironmentName"/>].json',
         ///     load <see cref="IConfiguration"/> from User Secrets when <see cref="IHostingEnvironment.EnvironmentName"/> is 'Development' using the entry assembly,
         ///     load <see cref="IConfiguration"/> from environment variables,
@@ -36,7 +36,7 @@ namespace MicroBatchFramework
         /// </summary>
         /// <remarks>
         ///   The following defaults are applied to the returned <see cref="HostBuilder"/>:
-        ///     set the <see cref="IHostingEnvironment.EnvironmentName"/> to the NETCORE_ENVIRONMENT,
+        ///     set the <see cref="IHostingEnvironment.EnvironmentName"/> to the DOTNET_ENVIRONMENT,
         ///     load <see cref="IConfiguration"/> from 'appsettings.json' and 'appsettings.[<see cref="IHostingEnvironment.EnvironmentName"/>].json',
         ///     load <see cref="IConfiguration"/> from User Secrets when <see cref="IHostingEnvironment.EnvironmentName"/> is 'Development' using the entry assembly,
         ///     load <see cref="IConfiguration"/> from environment variables,

--- a/src/MicroBatchFramework/BatchHost.cs
+++ b/src/MicroBatchFramework/BatchHost.cs
@@ -7,6 +7,7 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MicroBatchFramework
 {
@@ -63,10 +64,9 @@ namespace MicroBatchFramework
         /// <returns>The initialized <see cref="IHostBuilder"/>.</returns>
         public static IHostBuilder CreateDefaultBuilder(bool useSimpleConsoleLogger, LogLevel minSimpleConsoleLoggerLogLevel, string hostEnvironmentVariable)
         {
-            var builder = new HostBuilder();
+            var builder = Host.CreateDefaultBuilder();
 
             ConfigureHostConfigurationDefault(builder, hostEnvironmentVariable);
-            ConfigureAppConfigurationDefault(builder);
             ConfigureLoggingDefault(builder, useSimpleConsoleLogger, minSimpleConsoleLoggerLogLevel);
 
             return builder;
@@ -74,11 +74,12 @@ namespace MicroBatchFramework
 
         internal static void ConfigureHostConfigurationDefault(IHostBuilder builder, string hostEnvironmentVariable)
         {
-            builder.UseContentRoot(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
-
             builder.ConfigureHostConfiguration(config =>
             {
+                // NOTE: This is backward compatibility for v1.3.0 or before.
+                // It's strongly recommended to use "DOTNET_" prefix expected by GenericHost. (e.g. DOTNET_ENVIRONMENT)
                 config.AddEnvironmentVariables(prefix: "NETCORE_");
+
                 config.AddInMemoryCollection(new[] { new KeyValuePair<string, string>(HostDefaults.ApplicationKey, Assembly.GetExecutingAssembly().GetName().Name) });
             });
 
@@ -88,35 +89,19 @@ namespace MicroBatchFramework
             }
         }
 
-        internal static void ConfigureAppConfigurationDefault(IHostBuilder builder)
-        {
-            builder.ConfigureAppConfiguration((hostingContext, config) =>
-            {
-                var env = hostingContext.HostingEnvironment;
-
-                config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
-                config.AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true);
-
-                if (env.IsDevelopment())
-                {
-                    var appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
-                    if (appAssembly != null)
-                    {
-                        // use https://marketplace.visualstudio.com/items?itemName=guitarrapc.OpenUserSecrets to easily manage UserSecrets with GenericHost.
-                        config.AddUserSecrets(appAssembly, optional: true);
-                    }
-                }
-
-                config.AddEnvironmentVariables();
-            });
-        }
-
         internal static void ConfigureLoggingDefault(IHostBuilder builder, bool useSimpleConsoleLogger, LogLevel minSimpleConsoleLoggerLogLevel)
         {
             if (useSimpleConsoleLogger)
             {
                 builder.ConfigureLogging(logging =>
                 {
+                    // Use SimpleConsoleLogger instead of the default ConsoleLogger.
+                    var consoleLogger = logging.Services.FirstOrDefault(x => x.ImplementationType?.FullName == "Microsoft.Extensions.Logging.Console.ConsoleLoggerProvider");
+                    if (consoleLogger != null)
+                    {
+                        logging.Services.Remove(consoleLogger);
+                    }
+
                     logging.AddSimpleConsole();
                     logging.AddFilter<SimpleConsoleLoggerProvider>((category, level) =>
                     {

--- a/src/MicroBatchFramework/MicroBatchFramework.csproj
+++ b/src/MicroBatchFramework/MicroBatchFramework.csproj
@@ -26,10 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
   </ItemGroup>

--- a/tests/MicroBatchFramework.Tests/MicroBatchFramework.Tests.csproj
+++ b/tests/MicroBatchFramework.Tests/MicroBatchFramework.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/MicroBatchFramework.Tests/MicroBatchFramework.Tests.csproj
+++ b/tests/MicroBatchFramework.Tests/MicroBatchFramework.Tests.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" version="2.2.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" version="4.5.2" />
     <PackageReference Include="Utf8Json" version="1.3.7" />
   </ItemGroup>


### PR DESCRIPTION
Upgrade Microsoft.Extensions.Hosting to 3.0.0 and .NET Core to 3.0.

- MicroBatchFramework is still using .NET Standard 2.0
- MicroBatchFramework.WebHosting is now using ASP.NET Core 3.0

Microsoft.Extensions.Hosting 3.0.0 provides pre-configured generic `Host` class and its host builder. This PR makes MicroBatchFramework use `Host.CreateDefaultBuilder`.