### PR TITLE
Treat the return value as the exit code.

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -216,6 +216,30 @@ You can call like here.
 > SampleApp.exe -array [10,20,30] -person {"Age":10,"Name":"foo"}
 ```
 
+Exit Code
+---
+If the batch method returns `int` or `Task<int>` value, BatchEngine will set the return value to the exit code.
+
+```csharp
+public class ExampleBatch : BatchBase
+{
+    [Command(nameof(ExitCodeWithTask))]
+    public async Task<int> ExitCodeWithTask()
+    {
+        return 54321;
+    }
+
+    [Command(nameof(ExitCode))]
+    public int ExitCode()
+    {
+        return 12345;
+    }
+}
+```
+
+> **NOTE**: If the method throws an unhandled exception, BatchEngine always set `1` to the exit code.
+
+
 Daemon
 ---
 

--- a/src/MicroBatchFramework/BatchEngine.cs
+++ b/src/MicroBatchFramework/BatchEngine.cs
@@ -149,9 +149,17 @@ namespace MicroBatchFramework
             try
             {
                 var result = methodInfo.Invoke(instance, invokeArgs);
-                if (result is Task t)
+                switch (result)
                 {
-                    await t;
+                    case int exitCode:
+                        Environment.ExitCode = exitCode;
+                        break;
+                    case Task<int> taskWithExitCode:
+                        Environment.ExitCode = await taskWithExitCode;
+                        break;
+                    case Task task:
+                        await task;
+                        break;
                 }
             }
             catch (Exception ex)

--- a/tests/MicroBatchFramework.Tests/AssemblyInfo.cs
+++ b/tests/MicroBatchFramework.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/MicroBatchFramework.Tests/ExitCodeTest.cs
+++ b/tests/MicroBatchFramework.Tests/ExitCodeTest.cs
@@ -1,0 +1,114 @@
+using FluentAssertions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MicroBatchFramework.Tests
+{
+    public class ExitCodeTest
+    {
+        public class ExitCodeTestBatch : BatchBase
+        {
+            [Command(nameof(NoExitCode))]
+            public void NoExitCode()
+            {
+            }
+
+            [Command(nameof(NoExitCodeException))]
+            public void NoExitCodeException()
+            {
+                throw new Exception();
+            }
+
+            [Command(nameof(NoExitCodeWithTask))]
+            public Task NoExitCodeWithTask()
+            {
+                return Task.CompletedTask;
+            }
+
+            [Command(nameof(ExitCode))]
+            public int ExitCode()
+            {
+                return 12345;
+            }
+
+            [Command(nameof(ExitCodeException))]
+            public int ExitCodeException()
+            {
+                throw new Exception();
+            }
+
+            [Command(nameof(ExitCodeWithTask))]
+            public Task<int> ExitCodeWithTask()
+            {
+                return Task.FromResult(54321);
+            }
+
+            [Command(nameof(ExitCodeWithTaskException))]
+            public Task<int> ExitCodeWithTaskException()
+            {
+                throw new Exception();
+            }
+        }
+
+        [Fact]
+        public async Task NoExitCode()
+        {
+            Environment.ExitCode = 0;
+            await new HostBuilder().RunBatchEngineAsync<ExitCodeTestBatch>(new[] { nameof(NoExitCode) });
+            Assert.Equal(0, Environment.ExitCode);
+        }
+
+        [Fact]
+        public async Task NoExitCodeWithTask()
+        {
+            Environment.ExitCode = 0;
+            await new HostBuilder().RunBatchEngineAsync<ExitCodeTestBatch>(new[] { nameof(NoExitCodeWithTask) });
+            Assert.Equal(0, Environment.ExitCode);
+        }
+
+        [Fact]
+        public async Task NoExitCodeException()
+        {
+            Environment.ExitCode = 0;
+            await new HostBuilder().RunBatchEngineAsync<ExitCodeTestBatch>(new[] { nameof(NoExitCodeException) });
+            Assert.Equal(1, Environment.ExitCode);
+        }
+
+        [Fact]
+        public async Task ExitCode()
+        {
+            Environment.ExitCode = 0;
+            await new HostBuilder().RunBatchEngineAsync<ExitCodeTestBatch>(new[] { nameof(ExitCode) });
+            Assert.Equal(12345, Environment.ExitCode);
+        }
+
+        [Fact]
+        public async Task ExitCodeException()
+        {
+            Environment.ExitCode = 0;
+            await new HostBuilder().RunBatchEngineAsync<ExitCodeTestBatch>(new[] { nameof(ExitCodeException) });
+            Assert.Equal(1, Environment.ExitCode);
+        }
+
+        [Fact]
+        public async Task ExitCodeWithTask()
+        {
+            Environment.ExitCode = 0;
+            await new HostBuilder().RunBatchEngineAsync<ExitCodeTestBatch>(new[] { nameof(ExitCodeWithTask) });
+            Assert.Equal(54321, Environment.ExitCode);
+        }
+
+        [Fact]
+        public async Task ExitCodeWithTaskException()
+        {
+            Environment.ExitCode = 0;
+            await new HostBuilder().RunBatchEngineAsync<ExitCodeTestBatch>(new[] { nameof(ExitCodeWithTaskException) });
+            Assert.Equal(1, Environment.ExitCode);
+        }
+
+    }
+}


### PR DESCRIPTION
In some use cases, an application is expected to return `0`/`1` or other exit code.
This PR implements the ability to return the user-specified exit code.

- ref: #17 - Proposal: New API to return Exit Code
