### PR TITLE
Create scope service while BatchEngineService is starting.

### DIFF
--- a/sandbox/SingleContainedAppWithConfig/Program.cs
+++ b/sandbox/SingleContainedAppWithConfig/Program.cs
@@ -8,7 +8,7 @@ public class Baz : BatchBase
 {
     private readonly IOptions<SingleContainedAppWithConfig.AppConfig> config;
     // Batche inject Config on constructor.
-    public Baz(IOptions<SingleContainedAppWithConfig.AppConfig> config)
+    public Baz(IOptions<SingleContainedAppWithConfig.AppConfig> config, MyServiceA serviceA, MyServiceB serviceB, MyServiceC serviceC)
     {
         this.config = config;
     }
@@ -25,6 +25,9 @@ public class Baz : BatchBase
     }
 }
 
+public class MyServiceA { }
+public class MyServiceB { }
+public class MyServiceC { }
 
 namespace SingleContainedAppWithConfig
 {
@@ -39,6 +42,10 @@ namespace SingleContainedAppWithConfig
                     services.AddOptions();
                     // mapping json element to class
                     services.Configure<AppConfig>(hostContext.Configuration.GetSection("AppConfig"));
+
+                    services.AddScoped<MyServiceA>();
+                    services.AddTransient<MyServiceB>();
+                    services.AddSingleton<MyServiceC>();
                 })
                 .RunBatchEngineAsync<Baz>(args);
         }


### PR DESCRIPTION
Fix #21 

When the app is running in the `Development` environment, the default ServiceProvider validates about scope usage. (ref: [Scope Validation - Dependency Injection in ASP.NET Core | Microsoft Docs](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?view=aspnetcore-3.0#scope-validation))

This PR changes `BatchEngineService` to create scope at the start, so that provides the scoped services properly.

> **NOTE**: In BatchEngineService, `Scoped` service is almost same as `Singleton` service.