### PR TITLE
Remove the logger filter registration.

### DIFF
--- a/src/MicroBatchFramework/BatchHost.cs
+++ b/src/MicroBatchFramework/BatchHost.cs
@@ -100,21 +100,6 @@ namespace MicroBatchFramework
                     }
 
                     logging.AddSimpleConsole();
-                    logging.AddFilter((providerName, category, level) =>
-                    {
-                        if (providerName == typeof(SimpleConsoleLogger).FullName)
-                        {
-                            // omit system message
-                            if (category.StartsWith("Microsoft.Extensions.Hosting.Internal"))
-                            {
-                                if (level <= LogLevel.Debug) return false;
-                            }
-
-                            return level >= minSimpleConsoleLoggerLogLevel;
-                        }
-
-                        return true;
-                    });
                 });
             }
         }


### PR DESCRIPTION
Microsoft.Extensions.Logging's log filter selects **one** filter rule at once.
If multiple rules are matched, take the last one. The library should not depend on this behavior.

```csharp
logger
    .AddFilter((providerName, category, logLevel) =>
    {
        Console.WriteLine("AddFilter#1");
        return false;
    })
    .AddFilter((providerName, category, logLevel) =>
    {
        Console.WriteLine("AddFilter#2");
        return false;
    })
    .AddFilter((providerName, category, logLevel) =>
    {
        // On runtime, a logger uses this filter rule only.
        Console.WriteLine("AddFilter#3");
        return false;
    })
```