### PR TITLE
Enable Nullable Reference Type(annotations)

### DIFF
--- a/src/MicroBatchFramework.WebHosting/BatchEngineHostingExtensions.cs
+++ b/src/MicroBatchFramework.WebHosting/BatchEngineHostingExtensions.cs
@@ -14,7 +14,7 @@ namespace MicroBatchFramework // .WebHosting
 {
     public static class BatchEngineHostingExtensions
     {
-        public static IWebHostBuilder PrepareBatchEngineMiddleware(this IWebHostBuilder builder, IBatchInterceptor interceptor = null)
+        public static IWebHostBuilder PrepareBatchEngineMiddleware(this IWebHostBuilder builder, IBatchInterceptor? interceptor = null)
         {
             var batchTypes = CollectBatchTypes();
             var target = new TargetBatchTypeCollection(batchTypes);
@@ -31,7 +31,7 @@ namespace MicroBatchFramework // .WebHosting
                 });
         }
 
-        public static Task RunBatchEngineWebHosting(this IWebHostBuilder builder, string urls, SwaggerOptions swaggerOptions = null, IBatchInterceptor interceptor = null)
+        public static Task RunBatchEngineWebHosting(this IWebHostBuilder builder, string urls, SwaggerOptions? swaggerOptions = null, IBatchInterceptor? interceptor = null)
         {
             return builder
                 .PrepareBatchEngineMiddleware(interceptor)
@@ -43,7 +43,7 @@ namespace MicroBatchFramework // .WebHosting
                         var entryAsm = Assembly.GetEntryAssembly()!;
                         var xmlName = entryAsm.GetName().Name + ".xml";
                         var xmlPath = Path.Combine(Path.GetDirectoryName(entryAsm.Location) ?? "", xmlName);
-                        swaggerOptions = new SwaggerOptions(entryAsm.GetName().Name, "", "/") { XmlDocumentPath = xmlPath };
+                        swaggerOptions = new SwaggerOptions(entryAsm.GetName().Name!, "", "/") { XmlDocumentPath = xmlPath };
                     }
                     services.AddSingleton<SwaggerOptions>(swaggerOptions);
                 })
@@ -105,7 +105,7 @@ namespace MicroBatchFramework // .WebHosting
                 if (!(asm.FullName is null)
                     && (asm.FullName.StartsWith("System") || asm.FullName.StartsWith("Microsoft.Extensions"))) continue;
 
-                Type[] types;
+                Type[]? types;
                 try
                 {
                     types = asm.GetTypes();

--- a/src/MicroBatchFramework.WebHosting/BatchEngineMiddleware.cs
+++ b/src/MicroBatchFramework.WebHosting/BatchEngineMiddleware.cs
@@ -14,8 +14,8 @@ namespace MicroBatchFramework.WebHosting
         readonly IBatchInterceptor innerInterceptor;
 
         public bool CompleteSuccessfully { get; private set; }
-        public string ErrorMessage { get; private set; }
-        public Exception Exception { get; private set; }
+        public string? ErrorMessage { get; private set; }
+        public Exception? Exception { get; private set; }
 
         public WebHostingInterceptor(IBatchInterceptor innerInterceptor)
         {
@@ -37,7 +37,7 @@ namespace MicroBatchFramework.WebHosting
             return innerInterceptor.OnBatchRunBeginAsync(context);
         }
 
-        public ValueTask OnBatchRunCompleteAsync(BatchContext context, string errorMessageIfFailed, Exception exceptionIfExists)
+        public ValueTask OnBatchRunCompleteAsync(BatchContext context, string? errorMessageIfFailed, Exception? exceptionIfExists)
         {
             this.CompleteSuccessfully = (errorMessageIfFailed == null && exceptionIfExists == null);
             this.ErrorMessage = errorMessageIfFailed;
@@ -115,7 +115,7 @@ namespace MicroBatchFramework.WebHosting
             }
 
             // create args
-            string[] args = null;
+            string?[] args;
             try
             {
                 if (httpContext.Request.HasFormContentType)

--- a/src/MicroBatchFramework.WebHosting/MicroBatchFramework.WebHosting.csproj
+++ b/src/MicroBatchFramework.WebHosting/MicroBatchFramework.WebHosting.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
-    <Nullable>warnings</Nullable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MicroBatchFramework.WebHosting/Swagger/Schemas/SwaggerDocument.cs
+++ b/src/MicroBatchFramework.WebHosting/Swagger/Schemas/SwaggerDocument.cs
@@ -1,5 +1,5 @@
 ﻿// This definition is borrowed from Swashbuckle.
-
+#nullable disable annotations
 using Newtonsoft.Json;
 using System.Collections.Generic;
 

--- a/src/MicroBatchFramework.WebHosting/Swagger/SwaggerOptions.cs
+++ b/src/MicroBatchFramework.WebHosting/Swagger/SwaggerOptions.cs
@@ -12,9 +12,9 @@ namespace MicroBatchFramework.WebHosting.Swagger
         /// <summary>
         /// (FilePath, LoadedEmbeddedBytes) => CustomBytes)
         /// </summary>
-        public Func<string, byte[], byte[]> ResolveCustomResource { get; set; }
-        public Func<HttpContext, string> CustomHost { get; set; }
-        public string XmlDocumentPath { get; set; }
+        public Func<string, byte[]?, byte[]>? ResolveCustomResource { get; set; }
+        public Func<HttpContext, string>? CustomHost { get; set; }
+        public string? XmlDocumentPath { get; set; }
         public string JsonName { get; set; }
         public string[] ForceSchemas { get; set; }
 

--- a/src/MicroBatchFramework/BatchBase.cs
+++ b/src/MicroBatchFramework/BatchBase.cs
@@ -2,6 +2,10 @@
 {
     public abstract class BatchBase
     {
-        public BatchContext? Context { get; set; }
+        // Context will be set non-null value by BatchEngine,
+        // but it might be null because it has public setter.
+        #nullable disable warnings
+        public BatchContext Context { get; set; }
+        #nullable restore warnings
     }
 }

--- a/src/MicroBatchFramework/BatchBase.cs
+++ b/src/MicroBatchFramework/BatchBase.cs
@@ -2,6 +2,6 @@
 {
     public abstract class BatchBase
     {
-        public BatchContext Context { get; set; }
+        public BatchContext? Context { get; set; }
     }
 }

--- a/src/MicroBatchFramework/BatchContext.cs
+++ b/src/MicroBatchFramework/BatchContext.cs
@@ -6,12 +6,12 @@ namespace MicroBatchFramework
 {
     public class BatchContext
     {
-        public string[] Arguments { get; private set; }
+        public string?[] Arguments { get; private set; }
         public DateTime Timestamp { get; private set; }
         public CancellationToken CancellationToken { get; private set; }
         public ILogger<BatchEngine> Logger { get; private set; }
 
-        public BatchContext(string[] arguments, DateTime timestamp, CancellationToken cancellationToken, ILogger<BatchEngine> logger)
+        public BatchContext(string?[] arguments, DateTime timestamp, CancellationToken cancellationToken, ILogger<BatchEngine> logger)
         {
             Arguments = arguments;
             Timestamp = timestamp;

--- a/src/MicroBatchFramework/BatchEngine.cs
+++ b/src/MicroBatchFramework/BatchEngine.cs
@@ -38,7 +38,7 @@ namespace MicroBatchFramework
             logger.LogTrace("BatchEngine.Run Start");
 
             int argsOffset = 0;
-            MethodInfo method = null;
+            MethodInfo? method = null;
             var ctx = new BatchContext(args, DateTime.UtcNow, cancellationToken, logger);
             try
             {
@@ -57,7 +57,7 @@ namespace MicroBatchFramework
                     return;
                 }
 
-                MethodInfo helpMethod = null;
+                MethodInfo? helpMethod = null;
                 foreach (var item in methods)
                 {
                     var command = item.GetCustomAttribute<CommandAttribute>();
@@ -118,8 +118,8 @@ namespace MicroBatchFramework
 
         async Task RunCore(BatchContext ctx, Type type, MethodInfo methodInfo, string[] args, int argsOffset)
         {
-            object instance = null;
-            object[] invokeArgs = null;
+            object instance;
+            object[] invokeArgs;
 
             try
             {
@@ -199,7 +199,7 @@ namespace MicroBatchFramework
             await interceptor.OnBatchRunCompleteAsync(context, message, ex);
         }
 
-        static bool TryGetInvokeArguments(ParameterInfo[] parameters, string[] args, int argsOffset, out object[] invokeArgs, out string errorMessage)
+        static bool TryGetInvokeArguments(ParameterInfo[] parameters, string[] args, int argsOffset, out object[] invokeArgs, out string? errorMessage)
         {
             var argumentDictionary = ParseArgument(args, argsOffset);
             invokeArgs = new object[parameters.Length];
@@ -362,7 +362,8 @@ namespace MicroBatchFramework
                         }
                         else
                         {
-                            sb.Append("-" + option.ShortName.Trim('-') + ", ");
+                            // If Index is -1, ShortName is initialized at Constractor.
+                            sb.Append("-" + option.ShortName!.Trim('-') + ", ");
                         }
                     }
 

--- a/src/MicroBatchFramework/BatchEngineHostBuilderExtensions.cs
+++ b/src/MicroBatchFramework/BatchEngineHostBuilderExtensions.cs
@@ -13,7 +13,7 @@ namespace MicroBatchFramework
         const string ListCommand = "list";
         const string HelpCommand = "help";
 
-        public static IHostBuilder UseBatchEngine(this IHostBuilder hostBuilder, string[] args, IBatchInterceptor interceptor = null)
+        public static IHostBuilder UseBatchEngine(this IHostBuilder hostBuilder, string[] args, IBatchInterceptor? interceptor = null)
         {
             if (args.Length == 0 || (args.Length == 1 && args[0].Equals(ListCommand, StringComparison.OrdinalIgnoreCase)))
             {
@@ -44,8 +44,8 @@ namespace MicroBatchFramework
                 return hostBuilder;
             }
 
-            Type type = null;
-            MethodInfo methodInfo = null;
+            Type? type = null;
+            MethodInfo? methodInfo = null;
             if (args.Length >= 1)
             {
                 (type, methodInfo) = GetTypeFromAssemblies(args[0]);
@@ -77,12 +77,12 @@ namespace MicroBatchFramework
             return hostBuilder.UseConsoleLifetime();
         }
 
-        public static Task RunBatchEngineAsync(this IHostBuilder hostBuilder, string[] args, IBatchInterceptor interceptor = null)
+        public static Task RunBatchEngineAsync(this IHostBuilder hostBuilder, string[] args, IBatchInterceptor? interceptor = null)
         {
             return UseBatchEngine(hostBuilder, args, interceptor).Build().RunAsync();
         }
 
-        public static IHostBuilder UseBatchEngine<T>(this IHostBuilder hostBuilder, string[] args, IBatchInterceptor interceptor = null)
+        public static IHostBuilder UseBatchEngine<T>(this IHostBuilder hostBuilder, string[] args, IBatchInterceptor? interceptor = null)
             where T : BatchBase
         {
             var method = typeof(T).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
@@ -147,7 +147,7 @@ namespace MicroBatchFramework
             return hostBuilder.UseConsoleLifetime();
         }
 
-        public static Task RunBatchEngineAsync<T>(this IHostBuilder hostBuilder, string[] args, IBatchInterceptor interceptor = null)
+        public static Task RunBatchEngineAsync<T>(this IHostBuilder hostBuilder, string[] args, IBatchInterceptor? interceptor = null)
             where T : BatchBase
         {
             return UseBatchEngine<T>(hostBuilder, args, interceptor).Build().RunAsync();
@@ -196,7 +196,7 @@ namespace MicroBatchFramework
             return batchBaseTypes;
         }
 
-        static (Type, MethodInfo) GetTypeFromAssemblies(string arg0)
+        static (Type?, MethodInfo?) GetTypeFromAssemblies(string arg0)
         {
             var batchBaseTypes = GetBatchTypes();
             if (batchBaseTypes == null)
@@ -205,8 +205,8 @@ namespace MicroBatchFramework
             }
 
             var split = arg0.Split('.');
-            Type foundType = null;
-            MethodInfo foundMethod = null;
+            Type? foundType = null;
+            MethodInfo? foundMethod = null;
             foreach (var baseType in batchBaseTypes)
             {
                 bool isFound = false;

--- a/src/MicroBatchFramework/BatchEngineService.cs
+++ b/src/MicroBatchFramework/BatchEngineService.cs
@@ -12,12 +12,12 @@ namespace MicroBatchFramework
     {
         string[] args;
         Type type;
-        MethodInfo methodInfo;
+        MethodInfo? methodInfo;
         IHostApplicationLifetime appLifetime;
         ILogger<BatchEngine> logger;
         IServiceScope scope;
         IBatchInterceptor interceptor;
-        Task runningTask;
+        Task? runningTask;
         CancellationTokenSource cancellationTokenSource;
 
         public BatchEngineService(IHostApplicationLifetime appLifetime, Type type, string[] args, ILogger<BatchEngine> logger, IServiceProvider provider)
@@ -25,7 +25,7 @@ namespace MicroBatchFramework
         {
         }
 
-        public BatchEngineService(IHostApplicationLifetime appLifetime, Type type, MethodInfo methodInfo, string[] args, ILogger<BatchEngine> logger, IServiceProvider provider)
+        public BatchEngineService(IHostApplicationLifetime appLifetime, Type type, MethodInfo? methodInfo, string[] args, ILogger<BatchEngine> logger, IServiceProvider provider)
         {
             this.args = args;
             this.type = type;

--- a/src/MicroBatchFramework/CommandAttribute.cs
+++ b/src/MicroBatchFramework/CommandAttribute.cs
@@ -5,7 +5,7 @@ namespace MicroBatchFramework
     public class CommandAttribute : Attribute
     {
         public string[] CommandNames { get; }
-        public string Description { get; }
+        public string? Description { get; }
 
         public CommandAttribute(string commandName)
             : this(new[] { commandName }, null)
@@ -22,7 +22,7 @@ namespace MicroBatchFramework
         {
         }
 
-        public CommandAttribute(string[] commandNames, string description)
+        public CommandAttribute(string[] commandNames, string? description)
         {
             this.CommandNames = commandNames;
             this.Description = description;

--- a/src/MicroBatchFramework/CompositeBatchInterceptor.cs
+++ b/src/MicroBatchFramework/CompositeBatchInterceptor.cs
@@ -67,7 +67,7 @@ namespace MicroBatchFramework
             exceptions.ThrowIfExists();
         }
 
-        public async ValueTask OnBatchRunCompleteAsync(BatchContext context, string errorMessageIfFailed, Exception exceptionIfExists)
+        public async ValueTask OnBatchRunCompleteAsync(BatchContext context, string? errorMessageIfFailed, Exception? exceptionIfExists)
         {
             var exceptions = new AggregateExceptionHolder();
             foreach (var item in interceptors)

--- a/src/MicroBatchFramework/IBatchInterceptor.cs
+++ b/src/MicroBatchFramework/IBatchInterceptor.cs
@@ -24,7 +24,7 @@ namespace MicroBatchFramework
         /// <summary>
         /// Called when BatchMethod is error or completed.
         /// </summary>
-        ValueTask OnBatchRunCompleteAsync(BatchContext context, string errorMessageIfFailed, Exception exceptionIfExists);
+        ValueTask OnBatchRunCompleteAsync(BatchContext context, string? errorMessageIfFailed, Exception? exceptionIfExists);
     }
 
     public class NullBatchInterceptor : IBatchInterceptor
@@ -47,7 +47,7 @@ namespace MicroBatchFramework
             return Empty;
         }
 
-        public ValueTask OnBatchRunCompleteAsync(BatchContext context, string errorMessageIfFailed, Exception exceptionIfExists)
+        public ValueTask OnBatchRunCompleteAsync(BatchContext context, string? errorMessageIfFailed, Exception? exceptionIfExists)
         {
             return Empty;
         }

--- a/src/MicroBatchFramework/MicroBatchFramework.csproj
+++ b/src/MicroBatchFramework/MicroBatchFramework.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
-    <Nullable>warnings</Nullable>
+    <Nullable>enable</Nullable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>release.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/MicroBatchFramework/OptionAttribute.cs
+++ b/src/MicroBatchFramework/OptionAttribute.cs
@@ -6,8 +6,8 @@ namespace MicroBatchFramework
     public class OptionAttribute : Attribute
     {
         public int Index { get; }
-        public string ShortName { get; }
-        public string Description { get; }
+        public string? ShortName { get; }
+        public string? Description { get; }
 
         public OptionAttribute(int index)
         {


### PR DESCRIPTION
- set Nullable to `enable`
- fix warnings caused by NRT

This PR will be **BREAKING** change if this library is used in a `nullable` context.
It causes *only* warnings on some inappropriate code, but .NET has "treat warnings as errors" option. 

## Example
```csharp
using MicroBatchFramework;

public class BatchSample : BatchBase
{
    #nullable disable
    public void NoWarnCommand()
    {
        this.Context = null;  // No Warn
    }
    #nullable restore

    #nullable enable
    public void WarnCommand()
    {
        this.Context = null;  // Cause warning CS8625
    }
    #nullable restore
}
```