### PR TITLE
CustomSorter should return 0 when x equals y

### DIFF
--- a/src/MicroBatchFramework/BatchEngine.cs
+++ b/src/MicroBatchFramework/BatchEngine.cs
@@ -397,6 +397,11 @@ namespace MicroBatchFramework
         {
             public int Compare(MethodInfo x, MethodInfo y)
             {
+                if (x.Name == y.Name)
+                {
+                    return 0;
+                }
+
                 var xc = x.GetCustomAttribute<CommandAttribute>();
                 var yc = y.GetCustomAttribute<CommandAttribute>();
 


### PR DESCRIPTION
https://github.com/Cysharp/MicroBatchFramework/blob/6ddb766e20c5779d7b74b60012171d489df8eee9/src/MicroBatchFramework/BatchEngine.cs#L332
上記のOrderByで、xとyが一致するのにCustomSorterが1や-1を返すとソートが停止しない実装があるようです。以下のようなコマンドを定義した際、.NET Core3では止まりましたが、.NET Framwork 4.7.2で停止しませんでした。

```cs
public void Default() {}

[Command("last", "hoge")]
public void Last() {}

[Command("all", "piyo")]
public void All() {}
```


