### PR TITLE
Improve array handling, remove Utf8Json dependency

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -216,6 +216,29 @@ You can call like here.
 > SampleApp.exe -array [10,20,30] -person {"Age":10,"Name":"foo"}
 ```
 
+For the array handling, it can be a treat without correct JSON.
+e.g. one-length argument can handle without `[]`.
+
+```csharp
+Foo(int[] array)
+> SampleApp.exe -array 9999
+```
+
+multiple-argument can handle by split with ` `.
+
+```csharp
+Foo(int[] array)
+> SampleApp.exe -array "11 22 33"
+```
+
+string argument can handle without `"`.
+
+```csharp
+Foo(string[] array)
+> SampleApp.exe -array "hello"
+> SampleApp.exe -array "foo bar baz"
+```
+
 Exit Code
 ---
 If the batch method returns `int` or `Task<int>` value, BatchEngine will set the return value to the exit code.

--- a/sandbox/SingleContainedApp/Program.cs
+++ b/sandbox/SingleContainedApp/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Text;
@@ -114,9 +115,9 @@ namespace SingleContainedApp
 
     public class ComplexArgTest : BatchBase
     {
-        public void Foo(int[] array, Person person)
+        public void Foo(string[] array, Person person)
         {
-            Console.WriteLine(string.Join(", ", array));
+            Console.WriteLine(array.Length + ":" + string.Join(", ", array));
             Console.WriteLine(person.Age + ":" + person.Name);
         }
     }
@@ -131,7 +132,7 @@ namespace SingleContainedApp
     {
         static async Task Main(string[] args)
         {
-            args =  @"-array [10,20,30] -person {""Age"":10,""Name"":""foo""}".Split(' ');
+            args = new[] { "-array", "foo bar baz", "-person", @"{""Age"":10,""Name"":""foo""}" };
 
             await BatchHost.CreateDefaultBuilder()
                 .ConfigureServices((hostContext, services) =>

--- a/src/MicroBatchFramework.WebHosting/BatchEngineHostingExtensions.cs
+++ b/src/MicroBatchFramework.WebHosting/BatchEngineHostingExtensions.cs
@@ -3,6 +3,7 @@ using MicroBatchFramework.WebHosting.Swagger;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -66,7 +67,7 @@ namespace MicroBatchFramework // .WebHosting
 
         public class DefaultStartup
         {
-            public void Configure(IApplicationBuilder app, IApplicationLifetime lifetime)
+            public void Configure(IApplicationBuilder app, IHostApplicationLifetime lifetime)
             {
                 var interceptor = app.ApplicationServices.GetService<IBatchInterceptor>();
                 var provider = app.ApplicationServices.GetService<IServiceProvider>();

--- a/src/MicroBatchFramework.WebHosting/MicroBatchFramework.WebHosting.csproj
+++ b/src/MicroBatchFramework.WebHosting/MicroBatchFramework.WebHosting.csproj
@@ -1,25 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <LangVersion>8.0</LangVersion>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="Swagger\SwaggerUI\*" />
-  </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="Swagger\SwaggerUI\*" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="System.Text.Json" Version="4.7.0" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\MicroBatchFramework\MicroBatchFramework.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\MicroBatchFramework\MicroBatchFramework.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/src/MicroBatchFramework.WebHosting/Swagger/Schemas/SwaggerDocument.cs
+++ b/src/MicroBatchFramework.WebHosting/Swagger/Schemas/SwaggerDocument.cs
@@ -1,319 +1,319 @@
 ﻿// This definition is borrowed from Swashbuckle.
 #nullable disable annotations
-using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace MicroBatchFramework.WebHosting.Swagger.Schemas
 {
     public class SwaggerDocument
     {
-        public readonly string swagger = "2.0";
+        public string swagger { get; set; } = "2.0";
 
-        public Info info;
+        public Info info { get; set; }
 
-        public string host;
+        public string host { get; set; }
 
-        public string basePath;
+        public string basePath { get; set; }
 
-        public IList<string> schemes;
+        public IList<string> schemes { get; set; }
 
-        public IList<string> consumes;
+        public IList<string> consumes { get; set; }
 
-        public IList<string> produces;
+        public IList<string> produces { get; set; }
 
-        public IDictionary<string, PathItem> paths;
+        public IDictionary<string, PathItem> paths { get; set; }
 
-        public IDictionary<string, Schema> definitions;
+        public IDictionary<string, Schema> definitions { get; set; }
 
-        public IDictionary<string, Parameter> parameters;
+        public IDictionary<string, Parameter> parameters { get; set; }
 
-        public IDictionary<string, Response> responses;
+        public IDictionary<string, Response> responses { get; set; }
 
-        public IDictionary<string, SecurityScheme> securityDefinitions;
+        public IDictionary<string, SecurityScheme> securityDefinitions { get; set; }
 
-        public IList<IDictionary<string, IEnumerable<string>>> security;
+        public IList<IDictionary<string, IEnumerable<string>>> security { get; set; }
 
-        public IList<Tag> tags;
+        public IList<Tag> tags { get; set; }
 
-        public ExternalDocs externalDocs;
+        public ExternalDocs externalDocs { get; set; }
 
-        public Dictionary<string, object> vendorExtensions = new Dictionary<string, object>();
+        // public Dictionary<string, object> vendorExtensions { get; set; } = new Dictionary<string, object>();
     }
 
     public class Info
     {
-        public string version;
+        public string version { get; set; }
 
-        public string title;
+        public string title { get; set; }
 
-        public string description;
+        public string description { get; set; }
 
-        public string termsOfService;
+        public string termsOfService { get; set; }
 
-        public Contact contact;
+        public Contact contact { get; set; }
 
-        public License license;
+        public License license { get; set; }
 
-        public Dictionary<string, object> vendorExtensions = new Dictionary<string, object>();
+        // public Dictionary<string, object> vendorExtensions { get; set; } = new Dictionary<string, object>();
     }
 
     public class Contact
     {
-        public string name;
+        public string name { get; set; }
 
-        public string url;
+        public string url { get; set; }
 
-        public string email;
+        public string email { get; set; }
     }
 
     public class License
     {
-        public string name;
+        public string name { get; set; }
 
-        public string url;
+        public string url { get; set; }
     }
 
     public class PathItem
     {
-        [JsonProperty("$ref")]
-        public string @ref;
+        [JsonPropertyName("$ref")]
+        public string @ref { get; set; }
 
-        public Operation get;
+        public Operation get { get; set; }
 
-        public Operation put;
+        public Operation put { get; set; }
 
-        public Operation post;
+        public Operation post { get; set; }
 
-        public Operation delete;
+        public Operation delete { get; set; }
 
-        public Operation options;
+        public Operation options { get; set; }
 
-        public Operation head;
+        public Operation head { get; set; }
 
-        public Operation patch;
+        public Operation patch { get; set; }
 
-        public IList<Parameter> parameters;
+        public IList<Parameter> parameters { get; set; }
 
-        public Dictionary<string, object> vendorExtensions = new Dictionary<string, object>();
+        // public Dictionary<string, object> vendorExtensions { get; set; } = new Dictionary<string, object>();
     }
 
     public class Operation
     {
-        public IList<string> tags;
+        public IList<string> tags { get; set; }
 
-        public string summary;
+        public string summary { get; set; }
 
-        public string description;
+        public string description { get; set; }
 
-        public ExternalDocs externalDocs;
+        public ExternalDocs externalDocs { get; set; }
 
-        public string operationId;
+        public string operationId { get; set; }
 
-        public IList<string> consumes;
+        public IList<string> consumes { get; set; }
 
-        public IList<string> produces;
+        public IList<string> produces { get; set; }
 
-        public IList<Parameter> parameters;
+        public IList<Parameter> parameters { get; set; }
 
-        public IDictionary<string, Response> responses;
+        public IDictionary<string, Response> responses { get; set; }
 
-        public IList<string> schemes;
+        public IList<string> schemes { get; set; }
 
-        public bool? deprecated;
+        public bool? deprecated { get; set; }
 
-        public IList<IDictionary<string, IEnumerable<string>>> security;
+        public IList<IDictionary<string, IEnumerable<string>>> security { get; set; }
 
-        public Dictionary<string, object> vendorExtensions = new Dictionary<string, object>();
+        // public Dictionary<string, object> vendorExtensions { get; set; } = new Dictionary<string, object>();
     }
 
     public class Tag
     {
-        public string name;
+        public string name { get; set; }
 
-        public string description;
+        public string description { get; set; }
 
-        public ExternalDocs externalDocs;
+        public ExternalDocs externalDocs { get; set; }
 
-        public Dictionary<string, object> vendorExtensions = new Dictionary<string, object>();
+        // public Dictionary<string, object> vendorExtensions { get; set; } = new Dictionary<string, object>();
     }
 
     public class ExternalDocs
     {
-        public string description;
+        public string description { get; set; }
 
-        public string url;
+        public string url { get; set; }
     }
 
     public class Parameter : PartialSchema
     {
-        [JsonProperty("$ref")]
-        public string @ref;
+        [JsonPropertyName("$ref")]
+        public string @ref { get; set; }
 
-        public string name;
+        public string name { get; set; }
 
-        public string @in;
+        public string @in { get; set; }
 
-        public string description;
+        public string description { get; set; }
 
-        public bool? required;
+        public bool? required { get; set; }
 
-        public Schema schema;
+        public Schema schema { get; set; }
     }
 
     public class Schema
     {
-        [JsonProperty("$ref")]
-        public string @ref;
+        [JsonPropertyName("$ref")]
+        public string @ref { get; set; }
 
-        public string format;
+        public string format { get; set; }
 
-        public string title;
+        public string title { get; set; }
 
-        public string description;
+        public string description { get; set; }
 
-        public object @default;
+        public object @default { get; set; }
 
-        public int? multipleOf;
+        public int? multipleOf { get; set; }
 
-        public int? maximum;
+        public int? maximum { get; set; }
 
-        public bool? exclusiveMaximum;
+        public bool? exclusiveMaximum { get; set; }
 
-        public int? minimum;
+        public int? minimum { get; set; }
 
-        public bool? exclusiveMinimum;
+        public bool? exclusiveMinimum { get; set; }
 
-        public int? maxLength;
+        public int? maxLength { get; set; }
 
-        public int? minLength;
+        public int? minLength { get; set; }
 
-        public string pattern;
+        public string pattern { get; set; }
 
-        public int? maxItems;
+        public int? maxItems { get; set; }
 
-        public int? minItems;
+        public int? minItems { get; set; }
 
-        public bool? uniqueItems;
+        public bool? uniqueItems { get; set; }
 
-        public int? maxProperties;
+        public int? maxProperties { get; set; }
 
-        public int? minProperties;
+        public int? minProperties { get; set; }
 
-        public IList<string> required;
+        public IList<string> required { get; set; }
 
-        public IList<object> @enum;
+        public IList<object> @enum { get; set; }
 
-        public string type;
+        public string type { get; set; }
 
-        public Schema items;
+        public Schema items { get; set; }
 
-        public IList<Schema> allOf;
+        public IList<Schema> allOf { get; set; }
 
-        public IDictionary<string, Schema> properties;
+        public IDictionary<string, Schema> properties { get; set; }
 
-        public Schema additionalProperties;
+        public Schema additionalProperties { get; set; }
 
-        public string discriminator;
+        public string discriminator { get; set; }
 
-        public bool? readOnly;
+        public bool? readOnly { get; set; }
 
-        public Xml xml;
+        public Xml xml { get; set; }
 
-        public ExternalDocs externalDocs;
+        public ExternalDocs externalDocs { get; set; }
 
-        public object example;
+        public object example { get; set; }
 
-        public Dictionary<string, object> vendorExtensions = new Dictionary<string, object>();
+        // public Dictionary<string, object> vendorExtensions { get; set; } = new Dictionary<string, object>();
     }
 
     public class PartialSchema
     {
-        public string type;
+        public string type { get; set; }
 
-        public string format;
+        public string format { get; set; }
 
-        public PartialSchema items;
+        public PartialSchema items { get; set; }
 
-        public string collectionFormat;
+        public string collectionFormat { get; set; }
 
-        public object @default;
+        public object @default { get; set; }
 
-        public int? maximum;
+        public int? maximum { get; set; }
 
-        public bool? exclusiveMaximum;
+        public bool? exclusiveMaximum { get; set; }
 
-        public int? minimum;
+        public int? minimum { get; set; }
 
-        public bool? exclusiveMinimum;
+        public bool? exclusiveMinimum { get; set; }
 
-        public int? maxLength;
+        public int? maxLength { get; set; }
 
-        public int? minLength;
+        public int? minLength { get; set; }
 
-        public string pattern;
+        public string pattern { get; set; }
 
-        public int? maxItems;
+        public int? maxItems { get; set; }
 
-        public int? minItems;
+        public int? minItems { get; set; }
 
-        public bool? uniqueItems;
+        public bool? uniqueItems { get; set; }
 
-        public IList<object> @enum;
+        public IList<object> @enum { get; set; }
 
-        public int? multipleOf;
+        public int? multipleOf { get; set; }
 
-        public Dictionary<string, object> vendorExtensions = new Dictionary<string, object>();
+        // public Dictionary<string, object> vendorExtensions { get; set; } = new Dictionary<string, object>();
     }
 
     public class Response
     {
-        public string description;
+        public string description { get; set; }
 
-        public Schema schema;
+        public Schema schema { get; set; }
 
-        public IDictionary<string, Header> headers;
+        public IDictionary<string, Header> headers { get; set; }
 
-        public object examples;
+        public object examples { get; set; }
 
-        public Dictionary<string, object> vendorExtensions = new Dictionary<string, object>();
+        // public Dictionary<string, object> vendorExtensions { get; set; } = new Dictionary<string, object>();
     }
 
     public class Header : PartialSchema
     {
-        public string description;
+        public string description { get; set; }
     }
 
     public class Xml
     {
-        public string name;
+        public string name { get; set; }
 
-        public string @namespace;
+        public string @namespace { get; set; }
 
-        public string prefix;
+        public string prefix { get; set; }
 
-        public bool? attribute;
+        public bool? attribute { get; set; }
 
-        public bool? wrapped;
+        public bool? wrapped { get; set; }
     }
 
     public class SecurityScheme
     {
-        public string type;
+        public string type { get; set; }
 
-        public string description;
+        public string description { get; set; }
 
-        public string name;
+        public string name { get; set; }
 
-        public string @in;
+        public string @in { get; set; }
 
-        public string flow;
+        public string flow { get; set; }
 
-        public string authorizationUrl;
+        public string authorizationUrl { get; set; }
 
-        public string tokenUrl;
+        public string tokenUrl { get; set; }
 
-        public IDictionary<string, string> scopes;
+        public IDictionary<string, string> scopes { get; set; }
 
-        public Dictionary<string, object> vendorExtensions = new Dictionary<string, object>();
+        // public Dictionary<string, object> vendorExtensions { get; set; } = new Dictionary<string, object>();
     }
 }

--- a/src/MicroBatchFramework/BatchEngine.cs
+++ b/src/MicroBatchFramework/BatchEngine.cs
@@ -249,7 +249,22 @@ namespace MicroBatchFramework
                             var v = value.Value;
                             if (!(v.StartsWith("[") && v.EndsWith("]")))
                             {
-                                v = "[" + v + "]";
+                                var elemType = UnwrapCollectionElementType(parameters[i].ParameterType);
+                                if (elemType == typeof(string))
+                                {
+                                    if (!(v.StartsWith("\"") && v.EndsWith("\"")))
+                                    {
+                                        v = "[" + string.Join(",", v.Split(' ').Select(x => "\"" + x + "\"")) + "]";
+                                    }
+                                    else
+                                    {
+                                        v = "[" + v + "]";
+                                    }
+                                }
+                                else
+                                {
+                                    v = "[" + string.Join(",", v.Trim('\'', '\"').Split(' ')) + "]";
+                                }
                             }
                             try
                             {
@@ -284,13 +299,36 @@ namespace MicroBatchFramework
                 }
                 else
                 {
-                    errorMessage = "Required parameter \"" + item.Name + "\"" + " not found in argument.";
+                    var name = item.Name;
+                    if (option?.ShortName != null)
+                    {
+                        name = item.Name + "(" + "-" + option.ShortName + ")";
+                    }
+                    errorMessage = "Required parameter \"" + name + "\"" + " not found in argument.";
                     return false;
                 }
             }
 
             errorMessage = null;
             return true;
+        }
+
+        static Type? UnwrapCollectionElementType(Type collectionType)
+        {
+            if (collectionType.IsArray)
+            {
+                return collectionType.GetElementType();
+            }
+
+            foreach (var i in collectionType.GetInterfaces())
+            {
+                if (i.IsGenericType && (i.GetGenericTypeDefinition() == typeof(IEnumerable<>)))
+                {
+                    return i.GetGenericArguments()[0];
+                }
+            }
+
+            return null;
         }
 
         static ReadOnlyDictionary<string, OptionParameter> ParseArgument(string?[] args, int argsOffset)

--- a/src/MicroBatchFramework/BatchEngine.cs
+++ b/src/MicroBatchFramework/BatchEngine.cs
@@ -5,9 +5,9 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Utf8Json;
 
 namespace MicroBatchFramework
 {
@@ -253,7 +253,7 @@ namespace MicroBatchFramework
                             }
                             try
                             {
-                                invokeArgs[i] = JsonSerializer.NonGeneric.Deserialize(parameters[i].ParameterType, v);
+                                invokeArgs[i] = JsonSerializer.Deserialize(v, parameters[i].ParameterType);
                                 continue;
                             }
                             catch
@@ -264,10 +264,9 @@ namespace MicroBatchFramework
                         }
                         else
                         {
-                            // decouple dependency?
                             try
                             {
-                                invokeArgs[i] = JsonSerializer.NonGeneric.Deserialize(parameters[i].ParameterType, value.Value);
+                                invokeArgs[i] = JsonSerializer.Deserialize(value.Value, parameters[i].ParameterType);
                                 continue;
                             }
                             catch

--- a/src/MicroBatchFramework/EmptyHostedService.cs
+++ b/src/MicroBatchFramework/EmptyHostedService.cs
@@ -6,9 +6,9 @@ namespace MicroBatchFramework
 {
     internal class EmptyHostedService : IHostedService
     {
-        readonly IApplicationLifetime appLifetime;
+        readonly IHostApplicationLifetime appLifetime;
 
-        public EmptyHostedService(IApplicationLifetime appLifetime)
+        public EmptyHostedService(IHostApplicationLifetime appLifetime)
         {
             this.appLifetime = appLifetime;
         }

--- a/src/MicroBatchFramework/MicroBatchFramework.csproj
+++ b/src/MicroBatchFramework/MicroBatchFramework.csproj
@@ -1,35 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>8.0</LangVersion>
+        <Nullable>enable</Nullable>
+        <SignAssembly>true</SignAssembly>
+        <AssemblyOriginatorKeyFile>release.snk</AssemblyOriginatorKeyFile>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <Company>Cysharp</Company>
+        <!-- Version is passed from CircleCI -->
+        <!--<Version>1</Version>-->
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>release.snk</AssemblyOriginatorKeyFile>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Company>Cysharp</Company>
-    <!-- Version is passed from CircleCI -->
-    <!--<Version>1</Version>-->
+        <!-- NuGet -->
+        <PackageId>MicroBatchFramework</PackageId>
+        <PackageVersion>$(Version)</PackageVersion>
+        <Authors>Cysharp</Authors>
+        <Copyright>Cysharp</Copyright>
+        <Description>Cloud Native Batch Framework.</Description>
+        <PackageProjectUrl>https://github.com/Cysharp/MicroBatchFramework</PackageProjectUrl>
+        <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageTags>batch</PackageTags>
+    </PropertyGroup>
 
-    <!-- NuGet -->
-    <PackageId>MicroBatchFramework</PackageId>
-    <PackageVersion>$(Version)</PackageVersion>
-    <Authors>Cysharp</Authors>
-    <Copyright>Cysharp</Copyright>
-    <Description>Cloud Native Batch Framework.</Description>
-    <PackageProjectUrl>https://github.com/Cysharp/MicroBatchFramework</PackageProjectUrl>
-    <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>batch</PackageTags>
-  </PropertyGroup>
+    <PropertyGroup>
+        <NoWarn>1701;1702;1591</NoWarn>
+    </PropertyGroup>
 
-  <PropertyGroup>
-    <NoWarn>1701;1702;1591</NoWarn>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
-    <PackageReference Include="Utf8Json" Version="1.3.7" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
+        <PackageReference Include="System.Text.Json" Version="4.7.0" />
+        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
+    </ItemGroup>
 </Project>

--- a/tests/MicroBatchFramework.Tests/MicroBatchFramework.Tests.csproj
+++ b/tests/MicroBatchFramework.Tests/MicroBatchFramework.Tests.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" version="4.5.2" />
-    <PackageReference Include="Utf8Json" version="1.3.7" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" version="4.5.3" />
+      <PackageReference Include="System.Text.Json" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* using `System.Text.Json` instead of `Utf8Json`, `Newtonsoft.Json`.
* Array argument handling more friendly. (e.g. `int[]` can handle by `1 2 3`, `string[]` can handle by `foo bar baz`).